### PR TITLE
fix(page): Export Tool docs links broken

### DIFF
--- a/docs/dev-guide/licensing.md
+++ b/docs/dev-guide/licensing.md
@@ -22,10 +22,10 @@ website), and some older code using the BSD license or pubic domain.
 ## The GPLv3 and AGPLv3
 
 - These are strong 'copyleft' licences, meaning that anyone
-modifiying the software is required to make those changes openly
-available. This is commonly called the derivative work clause. Any
-derivative software must be contributes it back to the original
-software project with no restrictions.
+  modifiying the software is required to make those changes openly
+  available. This is commonly called the derivative work clause. Any
+  derivative software must be contributes it back to the original
+  software project with no restrictions.
 
 - The main purpose of this license is to prevent commercial
   exploitation of open code, making any modifications open so the
@@ -55,12 +55,12 @@ licenses](https://www.gnu.org/licenses/license-list.en.html). This in
 far from an exhaustive list, only the most common ones are listed
 here.
 
-* Public Domain
-* Mozilla Public License (MPL) version 2.0
-* Apache License 2.0
-* Modified BSD license
-* Intel Open Source License
-* FreeBSD license
+- Public Domain
+- Mozilla Public License (MPL) version 2.0
+- Apache License 2.0
+- Modified BSD license
+- Intel Open Source License
+- FreeBSD license
 
 ### Incompatible Licenses
 
@@ -72,15 +72,15 @@ HOT even though they are considered premissive licenses.
 Here is a short list of common non-permissive licenses, and can't be
 used for any code in HOT software projects.
 
-* Mozilla Public License (MPL) version 1.1
-* Apache License, Version 1.0 and 1.1
-* Apple Public Source License (APSL), version 2
-* Microsoft Public License (Ms-PL)
-* NASA Open Source Agreement
-* Original BSD license
-* Common Development and Distribution License (CDDL), version 1.0
-* Common Public Attribution License 1.0 (CPAL)
-* Common Public License Version 1.0
-* European Union Public License (EUPL) version 1.1 and 1.2
-* IBM Public License, Version 1.0
-* Open Software License, all versions through 3.0
+- Mozilla Public License (MPL) version 1.1
+- Apache License, Version 1.0 and 1.1
+- Apple Public Source License (APSL), version 2
+- Microsoft Public License (Ms-PL)
+- NASA Open Source Agreement
+- Original BSD license
+- Common Development and Distribution License (CDDL), version 1.0
+- Common Public Attribution License 1.0 (CPAL)
+- Common Public License Version 1.0
+- European Union Public License (EUPL) version 1.1 and 1.2
+- IBM Public License, Version 1.0
+- Open Software License, all versions through 3.0

--- a/docs/e2e-overview.md
+++ b/docs/e2e-overview.md
@@ -87,7 +87,7 @@ validator directly in fAIr would be good enough.
 
 ### 8. Extract from OpenSreetMap
 
-- Now final validation from FMTM is uploaded to OpenStreetMap , Now we need to download them in useful fileformats that we want 
-- This will be achieved with HOT Export Tool which allows us to export the data we created in different file formats including ( Shpaefile , Geojson , KML , CSV , Flatgeobuff and manymore ) 
+- Now final validation from FMTM is uploaded to OpenStreetMap , Now we need to download them in useful fileformats that we want
+- This will be achieved with HOT Export Tool which allows us to export the data we created in different file formats including ( Shpaefile , Geojson , KML , CSV , Flatgeobuff and manymore )
 
 🚧 A way to feed validation failures back to TM for re-digitisation would be great.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,10 +5,9 @@ multiple tools, and working towards an end to end data flow between
 projects. Since often a disaster response, or humanitarian mapping
 campaign, a project manager or mapper may use the [Tasking
 Manager](https://hotosm.github.io/tasking-manager/), [Export Tool](https://github.com/hotosm/osm-export-tool),
-[fAIr](https://fair-dev.hotosm.org/), 
+[fAIr](https://fair-dev.hotosm.org/),
 [FMTM](https://hotosm.github.io/fmtm/), etc... For more information,
 here's a short [E2E Presentation](techdoc/e2e.pdf).
-
 
 To improve maintainability of the code base, the Text Team has been
 working on modularizing all of our projects. Rather than duplicating
@@ -23,4 +22,3 @@ more detailed information on modularization [here](modules.md).
 ## Overall Architecture
 
 ![detailed-e2e](./images/hot-components-model.png)
-

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ The HOT Tech Team is working to improve the user experience across
 multiple tools, and working towards an end to end data flow between
 projects. Since often a disaster response, or humanitarian mapping
 campaign, a project manager or mapper may use the [Tasking
-Manager](https://hotosm.github.io/tasking-manager/), [Export Tool](https://hotosm.github.io/osm-export-tool/),
+Manager](https://hotosm.github.io/tasking-manager/), [Export Tool](https://github.com/hotosm/osm-export-tool),
 [fAIr](https://fair-dev.hotosm.org/), 
 [FMTM](https://hotosm.github.io/fmtm/), etc... For more information,
 here's a short [E2E Presentation](techdoc/e2e.pdf).

--- a/docs/techdoc/overview/README.md
+++ b/docs/techdoc/overview/README.md
@@ -4,10 +4,11 @@ While today HOT architecture consists of a wide range of applications
 and modules, the vision for the future is a more unified ecosystem.
 
 The key features of this architecture are:
-* An integrated set of back-end modules
-* A common data model based on standards and only extending as
+
+- An integrated set of back-end modules
+- A common data model based on standards and only extending as
   required
-* Fit for purpose front-ends, built on REACT
+- Fit for purpose front-ends, built on REACT
 
 ## HOT Overview
 

--- a/docs/tools-summary.md
+++ b/docs/tools-summary.md
@@ -164,4 +164,3 @@ As with TM, another tool, StreeComplete, can help with this & may be
 part of the solution.
 
 However, FMTM allows mapping to be done **collaboratively**.
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ nav:
           - Browser: https://hotosm.github.io/oam-browser/
           - API: https://hotosm.github.io/oam-api/
       - Export Tool:
-          - Docs: https://hotosm.github.io/osm-export-tool/
+          - Docs: https://github.com/hotosm/osm-export-tool
           - Roadmap: https://github.com/orgs/hotosm/projects/29
           - Task Tracker: https://github.com/orgs/hotosm/projects/29/views/2
       - Roadmap: roadmap.md


### PR DESCRIPTION
Changed a link that seems to be broken to point to GitHub instead. 